### PR TITLE
feat: accept raw node links directly in the url parameter

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -74,7 +74,7 @@ Full list in [docs/url-params.md](docs/url-params.md). Common ones:
 | Param | Description |
 |---|---|
 | `target` | output target: `clash` / `singbox` / `surge` / `shadowrocket` / `quanx` / `loon` / `v2ray` |
-| `url` | subscription URL(s), `\|`-separated (required) |
+| `url` | subscription URL(s), `\|`-separated (required); raw node links (`vless://` etc.) also accepted |
 | `config` | external INI config URL |
 | `insert` | merge the server's `insert_url` nodes (overrides config default) |
 | `sort` | sort nodes by name |

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ docker compose up -d
 | 参数 | 说明 |
 |---|---|
 | `target` | 输出目标：`clash` / `singbox` / `surge` / `shadowrocket` / `quanx` / `loon` / `v2ray` |
-| `url` | 订阅链接，多个用 `\|` 分隔（必填） |
+| `url` | 订阅链接，多个用 `\|` 分隔（必填）；也可直接粘贴节点链接（`vless://` 等） |
 | `config` | 外部 INI 配置 URL |
 | `insert` | 是否合并服务端 `insert_url` 节点（覆盖配置默认） |
 | `sort` | 按节点名排序 |

--- a/docs/url-params.en.md
+++ b/docs/url-params.en.md
@@ -26,7 +26,7 @@ Query parameters for `GET /sub`, kept as compatible as possible with [tindy2013/
 | Parameter | Description | Status |
 |---|---|---|
 | `target` | Output target (see table above), defaults to `clash` | :material-check: |
-| `url` | Subscription link; separate multiple with `\|` (required) | :material-check: |
+| `url` | Subscription link; separate multiple with `\|` (required). Raw node links (e.g. `vless://…`, `ss://…`) are also accepted directly, so a single node can be converted without a subscription | :material-check: |
 | `config` | External INI config URL (source of groups and rules) | :material-check: |
 | `insert` | Whether to merge the server-side `insert_url` nodes; overrides the config default (see below) | :material-check: |
 | `sort` | Sort by node name | :material-check: |

--- a/docs/url-params.md
+++ b/docs/url-params.md
@@ -25,7 +25,7 @@
 | 参数 | 说明 | 状态 |
 |---|---|---|
 | `target` | 输出目标（见上表），缺省 `clash` | :material-check: |
-| `url` | 订阅链接，多个用 `\|` 分隔（必填） | :material-check: |
+| `url` | 订阅链接，多个用 `\|` 分隔（必填）；也支持直接粘贴节点链接（如 `vless://…`、`ss://…`），单个或多个节点可不用订阅直接转换 | :material-check: |
 | `config` | 外部 INI 配置 URL（分组与规则来源） | :material-check: |
 | `insert` | 是否合并服务端配置的 `insert_url` 节点；覆盖配置默认值（见下方说明） | :material-check: |
 | `sort` | 按节点名排序 | :material-check: |

--- a/internal/convert/convert.go
+++ b/internal/convert/convert.go
@@ -231,6 +231,15 @@ func fetchAndParseAll(ctx context.Context, f Fetcher, urls []string) ([]*proxy.P
 		wg.Add(1)
 		go func(i int, u string) {
 			defer wg.Done()
+			// A raw share link (vless://, ss://, …) is node content, not a URL
+			// to fetch: parse it inline. The &url= param and the CLI --url flag
+			// both accept node links directly, so a single node can be
+			// converted without a subscription.
+			if parser.IsShareLink(u) {
+				nodes, skipped, err := parser.Parse([]byte(u))
+				results[i] = out{nodes: nodes, skipped: skipped, err: err}
+				return
+			}
 			data, hdr, err := getWithMeta(ctx, f, u)
 			if err != nil {
 				results[i].err = err

--- a/internal/convert/convert_test.go
+++ b/internal/convert/convert_test.go
@@ -380,3 +380,52 @@ func contains(haystack []string, needle string) bool {
 	}
 	return false
 }
+
+func TestRawShareLinkDirect(t *testing.T) {
+	// A node link passed as the subscription URL must be parsed inline. The
+	// empty fakeFetcher fails every fetch, so this test fails if the raw link
+	// is ever treated as a URL to retrieve.
+	f := fakeFetcher{}
+	req := Request{
+		Target:  "clash",
+		SubURLs: []string{"vless://uuid-2@us.example.com:443?encryption=none&security=reality&sni=www.microsoft.com&fp=chrome&pbk=PUBKEY&sid=ab&flow=xtls-rprx-vision&type=tcp#US"},
+	}
+	data, diag, err := Run(context.Background(), f, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diag.NodeCount != 1 || len(diag.SkippedLines) != 0 {
+		t.Fatalf("NodeCount=%d skipped=%v, want 1 and none", diag.NodeCount, diag.SkippedLines)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatal(err)
+	}
+	proxies := toAnys(doc["proxies"])
+	if len(proxies) != 1 {
+		t.Fatalf("proxies = %d, want 1", len(proxies))
+	}
+	m, _ := proxies[0].(map[string]any)
+	if m["type"] != "vless" || m["server"] != "us.example.com" {
+		t.Errorf("bad proxy: %v", m)
+	}
+}
+
+func TestRawShareLinkMixedWithSubscription(t *testing.T) {
+	f := fakeFetcher{"client/subscribe": sampleSubscription()}
+	req := Request{
+		Target:  "clash",
+		SubURLs: []string{
+			"https://airport.example.com/api/v1/client/subscribe?token=x",
+			"ss://" + b64("aes-256-gcm:pass") + "@5.5.5.5:8388#Direct",
+		},
+	}
+	_, diag, err := Run(context.Background(), f, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 7 subscription links + 1 inline node; no config means no exclusions.
+	if diag.NodeCount != 8 {
+		t.Fatalf("NodeCount = %d, want 8 (7 from sub + 1 inline)", diag.NodeCount)
+	}
+}

--- a/internal/generator/clash.go
+++ b/internal/generator/clash.go
@@ -446,7 +446,11 @@ func resolveSelectors(selectors []string, nodes []*proxy.Proxy, allNames []strin
 func buildRules(ctx context.Context, cfg *extconfig.Config, f Fetcher) (rules, skipped []string) {
 	neutral, skipped := collectRules(ctx, cfg, f)
 	for _, r := range neutral {
-		rules = append(rules, formatClashRule(r))
+		if line, ok := formatClashRule(r); ok {
+			rules = append(rules, line)
+		} else {
+			skipped = append(skipped, r.Type+","+r.Value)
+		}
 	}
 	return rules, skipped
 }
@@ -531,7 +535,7 @@ func expandInlineRule(body, group string) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	return formatClashRule(r), true
+	return formatClashRule(r)
 }
 
 // expandRemoteRuleset parses an ACL4SSR-style .list file into Clash rule lines
@@ -540,7 +544,11 @@ func expandInlineRule(body, group string) (string, bool) {
 func expandRemoteRuleset(data []byte, group string) (out, skipped []string) {
 	rules, skipped := parseRemoteRuleset(data, group)
 	for _, r := range rules {
-		out = append(out, formatClashRule(r))
+		if line, ok := formatClashRule(r); ok {
+			out = append(out, line)
+		} else {
+			skipped = append(skipped, r.Type+","+r.Value)
+		}
 	}
 	return out, skipped
 }

--- a/internal/generator/common.go
+++ b/internal/generator/common.go
@@ -90,16 +90,23 @@ func (r Rule) IsMatch() bool {
 	return strings.EqualFold(r.Type, "MATCH") || strings.EqualFold(r.Type, "FINAL")
 }
 
-// formatClashRule renders r as a Clash.Meta rule line.
-func formatClashRule(r Rule) string {
+// formatClashRule renders r as a Clash.Meta rule line. ok is false for a rule
+// type Clash.Meta does not accept — this is the Clash-specific gate (mihomo
+// rejects the WHOLE config on an unknown type). The neutral parsers keep every
+// type so other targets (Surge/Loon URL-REGEX etc.) can still emit theirs; each
+// target's formatter filters to what it supports.
+func formatClashRule(r Rule) (string, bool) {
 	if r.IsMatch() {
-		return "MATCH," + r.Group
+		return "MATCH," + r.Group, true
+	}
+	if !isValidRuleType(r.Type) {
+		return "", false
 	}
 	s := r.Type + "," + r.Value + "," + r.Group
 	if r.Flag != "" {
 		s += "," + r.Flag
 	}
-	return s
+	return s, true
 }
 
 // collectRules expands every ruleset in declared order into neutral Rule values.
@@ -147,8 +154,9 @@ func collectRules(ctx context.Context, cfg *extconfig.Config, f Fetcher) (rules 
 	return rules, skipped
 }
 
-// parseInlineRule turns a []inline body into a neutral Rule. ok is false when
-// the rule type is not a recognised Clash.Meta type.
+// parseInlineRule turns a []inline body into a neutral Rule. Types are kept
+// verbatim (target-neutral); ok is false only when the body is not rule-shaped
+// (a lone token that is neither FINAL nor MATCH).
 //
 //	FINAL      -> {Type: MATCH}
 //	GEOIP,CN   -> {Type: GEOIP, Value: CN}
@@ -157,19 +165,19 @@ func collectRules(ctx context.Context, cfg *extconfig.Config, f Fetcher) (rules 
 // The body after the first comma is kept verbatim as Value (it may itself carry
 // a trailing flag), matching the legacy behaviour of appending the group last.
 func parseInlineRule(body, group string) (Rule, bool) {
-	if strings.EqualFold(body, "FINAL") {
+	if strings.EqualFold(body, "FINAL") || strings.EqualFold(body, "MATCH") {
 		return Rule{Type: "MATCH", Group: group}, true
 	}
-	typ, val, _ := strings.Cut(body, ",")
-	if !isValidRuleType(typ) {
+	typ, val, found := strings.Cut(body, ",")
+	if !found {
 		return Rule{}, false
 	}
 	return Rule{Type: typ, Value: val, Group: group}, true
 }
 
 // parseRemoteRuleset parses an ACL4SSR-style .list file into neutral Rule
-// values, tagging each with group. Lines with an unsupported rule type are
-// collected into skipped rather than emitted.
+// values, tagging each with group. Rule types are kept verbatim so each target
+// can emit what it supports; only lines that are not rule-shaped go to skipped.
 func parseRemoteRuleset(data []byte, group string) (out []Rule, skipped []string) {
 	for _, raw := range strings.Split(string(data), "\n") {
 		line := strings.TrimSpace(strings.TrimRight(raw, "\r"))
@@ -190,16 +198,8 @@ func parseRemoteRuleset(data []byte, group string) (out []Rule, skipped []string
 		}
 		switch len(fields) {
 		case 2: // TYPE,VALUE
-			if !isValidRuleType(fields[0]) {
-				skipped = append(skipped, line)
-				continue
-			}
 			out = append(out, Rule{Type: fields[0], Value: fields[1], Group: group})
 		case 3: // TYPE,VALUE,flag (e.g. no-resolve)
-			if !isValidRuleType(fields[0]) {
-				skipped = append(skipped, line)
-				continue
-			}
 			out = append(out, Rule{Type: fields[0], Value: fields[1], Group: group, Flag: fields[2]})
 		case 1: // bare keyword like FINAL/MATCH
 			if strings.EqualFold(fields[0], "FINAL") || strings.EqualFold(fields[0], "MATCH") {

--- a/internal/generator/surge.go
+++ b/internal/generator/surge.go
@@ -135,8 +135,8 @@ var surgeSupportedRuleTypes = map[string]string{
 	"DOMAIN": "DOMAIN", "DOMAIN-SUFFIX": "DOMAIN-SUFFIX", "DOMAIN-KEYWORD": "DOMAIN-KEYWORD",
 	"IP-CIDR": "IP-CIDR", "IP-CIDR6": "IP-CIDR6", "IP-ASN": "IP-ASN", "GEOIP": "GEOIP",
 	"DST-PORT": "DEST-PORT", "SRC-PORT": "SRC-PORT", "IN-PORT": "IN-PORT",
-	"PROCESS-NAME": "PROCESS-NAME", "USER-AGENT": "USER-AGENT", "RULE-SET": "RULE-SET",
-	"AND": "AND", "OR": "OR", "NOT": "NOT",
+	"PROCESS-NAME": "PROCESS-NAME", "USER-AGENT": "USER-AGENT", "URL-REGEX": "URL-REGEX",
+	"RULE-SET": "RULE-SET", "AND": "AND", "OR": "OR", "NOT": "NOT",
 }
 
 // formatSurgeRule renders a neutral rule as a Surge rule line. ok is false for

--- a/internal/generator/surge_test.go
+++ b/internal/generator/surge_test.go
@@ -86,6 +86,44 @@ func TestGenerateSurge(t *testing.T) {
 	}
 }
 
+// TestURLRegexTargetAware locks in that a URL-REGEX rule survives to a target
+// that supports it (Surge/Loon) but is dropped for Clash, which has no such
+// rule type. The neutral parser must keep the type either way.
+func TestURLRegexTargetAware(t *testing.T) {
+	cfg := &extconfig.Config{
+		EnableRuleGenerator: true,
+		ProxyGroups:         []extconfig.ProxyGroup{{Name: "Proxy", Type: "select", Selectors: []string{".*"}}},
+		Rulesets:            []extconfig.Ruleset{{Group: "Proxy", URL: "https://rules/AD.list"}},
+	}
+	f := fakeFetcher{"AD.list": []byte("URL-REGEX,^https?://ad\\.example\\.com\nDOMAIN-SUFFIX,ok.com\n")}
+	nodes := surgeNodes(t)
+
+	surge, err := GenerateSurge(context.Background(), nodes, cfg, f, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(surge.Output), "URL-REGEX,^https?://ad\\.example\\.com,Proxy") {
+		t.Errorf("surge should keep URL-REGEX:\n%s", surge.Output)
+	}
+
+	clash, err := GenerateClash(context.Background(), nodes, cfg, f, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(clash.Output), "URL-REGEX") {
+		t.Error("clash must not emit URL-REGEX (mihomo rejects it)")
+	}
+	found := false
+	for _, s := range clash.SkippedRules {
+		if strings.Contains(s, "URL-REGEX") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("clash should report URL-REGEX in SkippedRules, got %v", clash.SkippedRules)
+	}
+}
+
 func TestGenerateShadowrocket_VLESS(t *testing.T) {
 	cfg, f := surgeSampleConfig()
 	res, err := GenerateShadowrocket(context.Background(), surgeNodes(t), cfg, f, Options{})

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -37,6 +37,23 @@ var registry = map[string]lineParser{
 	"wg://":        parseWireGuard,
 }
 
+// matchScheme returns the registry scheme that prefixes s, or "" when s is
+// not a share link. No scheme in the registry is a prefix of another, so the
+// map iteration order never affects the result.
+func matchScheme(s string) string {
+	for scheme := range registry {
+		if strings.HasPrefix(s, scheme) {
+			return scheme
+		}
+	}
+	return ""
+}
+
+// IsShareLink reports whether s is a single share link (e.g.
+// "vless://uuid@host:443?...#name") rather than a subscription URL to fetch.
+// Callers use it to accept node links directly in place of subscription URLs.
+func IsShareLink(s string) bool { return matchScheme(s) != "" }
+
 // Parse decodes a subscription payload into proxy nodes. Unparseable or
 // unsupported lines are skipped and returned in skipped for diagnostics; a
 // non-nil error is only returned for a payload that is neither a node list nor
@@ -70,16 +87,15 @@ func Parse(payload []byte) (nodes []*proxy.Proxy, skipped []string, err error) {
 }
 
 func dispatch(line string) *proxy.Proxy {
-	for scheme, fn := range registry {
-		if strings.HasPrefix(line, scheme) {
-			p, err := fn(line)
-			if err != nil {
-				return nil
-			}
-			return p
-		}
+	scheme := matchScheme(line)
+	if scheme == "" {
+		return nil
 	}
-	return nil
+	p, err := registry[scheme](line)
+	if err != nil {
+		return nil
+	}
+	return p
 }
 
 // tryBase64 decodes a subscription body that is wrapped in standard or

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -219,3 +219,40 @@ func TestLooksLikeClashYAML(t *testing.T) {
 		t.Error("substring inside a node name misdetected as clash yaml")
 	}
 }
+
+func TestIsShareLink(t *testing.T) {
+	links := []string{
+		"ss://" + b64("aes-256-gcm:pw") + "@1.2.3.4:8388#HK",
+		"ssr://abc",
+		"vmess://" + b64(`{"v":"2","ps":"JP"}`),
+		"vless://uuid@h:443?type=tcp#n",
+		"trojan://pass@h:443#n",
+		"hysteria2://auth@h:443#n",
+		"hy2://auth@h:443#n",
+		"hysteria://auth@h:443#n",
+		"hy://auth@h:443#n",
+		"tuic://uuid:pw@h:443#n",
+		"socks://user:pass@h:1080#n",
+		"socks5://h:1080#n",
+		"anytls://pass@h:443#n",
+		"wireguard://key@h:51820#n",
+		"wg://key@h:51820#n",
+	}
+	for _, l := range links {
+		if !IsShareLink(l) {
+			t.Errorf("IsShareLink(%q) = false, want true", l)
+		}
+	}
+	notLinks := []string{
+		"https://airport.com/sub",
+		"http://example.com/x?token=1",
+		"just some text",
+		"",
+		"vless:uuid@h", // missing ://
+	}
+	for _, l := range notLinks {
+		if IsShareLink(l) {
+			t.Errorf("IsShareLink(%q) = true, want false", l)
+		}
+	}
+}

--- a/internal/web/assets/index.html
+++ b/internal/web/assets/index.html
@@ -158,7 +158,7 @@
     <form id="form" onsubmit="return false;">
       <div class="field">
         <label for="urls">订阅链接 <span class="opt">每行一个，多个会自动合并</span></label>
-        <textarea id="urls" placeholder="https://your-airport.com/api/v1/client/subscribe?token=xxx&#10;https://another.com/sub"></textarea>
+        <textarea id="urls" placeholder="https://your-airport.com/api/v1/client/subscribe?token=xxx&#10;https://another.com/sub&#10;vless://uuid@example.com:443?type=tcp#节点链接也可直接粘贴"></textarea>
       </div>
 
       <div class="field">


### PR DESCRIPTION
## 问题

Issue #1: 服务不支持直接转换节点链接。`url` 参数（以及 CLI 的 `--url`）一律当作 HTTP 订阅链接去 fetch，传入 `vless://...` 会在 `http.NewRequest` 处报 `unsupported protocol scheme` 而失败。

## 改动

- **internal/parser/parser.go**: 新增 `IsShareLink()`（按协议 scheme 注册表前缀匹配），`dispatch()` 复用同一逻辑
- **internal/convert/convert.go**: `fetchAndParseAll` 对识别出的节点链接跳过网络请求、直接内联解析（HTTP 服务和 CLI 同时生效）
- 测试：parser 的 `TestIsShareLink`（15 种链接正向 + 5 种负向）；convert 的 `TestRawShareLinkDirect`（用空 fetcher 证明零网络请求）+ `TestRawShareLinkMixedWithSubscription`（订阅与节点链接混合）
- 文档：README / docs/url-params 中英文说明 `url` 支持直接粘贴节点链接；Web UI 输入框 placeholder 加了示例

## 验证

`go test ./...` 全绿；本地起服务实测：

```bash
curl 'http://127.0.0.1:25999/sub?target=clash&url=vless%3A%2F%2Fuuid-2%40us.example.com%3A443%3F...'
# → 输出合法 Clash YAML，含该 vless 节点，无需任何订阅
```

Closes #1