### PR TITLE
feat: support socks5, socks5h, and socks share-links across all generators

### DIFF
--- a/internal/convert/convert_test.go
+++ b/internal/convert/convert_test.go
@@ -429,3 +429,29 @@ func TestRawShareLinkMixedWithSubscription(t *testing.T) {
 		t.Fatalf("NodeCount = %d, want 8 (7 from sub + 1 inline)", diag.NodeCount)
 	}
 }
+
+func TestRawSocks5ShareLinkDirect(t *testing.T) {
+	// A socks5 link (like socks5://100.106.251.111:1080#Tailscale) passed directly
+	// in SubURLs must be parsed inline and converted for all targets without network fetch.
+	f := fakeFetcher{}
+	socks5URL := "socks5://100.106.251.111:1080#Tailscale"
+
+	for _, target := range []string{"clash", "singbox", "surge", "shadowrocket", "loon", "quanx", "v2ray"} {
+		t.Run(target, func(t *testing.T) {
+			req := Request{
+				Target:  target,
+				SubURLs: []string{socks5URL},
+			}
+			data, diag, err := Run(context.Background(), f, req)
+			if err != nil {
+				t.Fatalf("Run target %s: %v", target, err)
+			}
+			if diag.NodeCount != 1 {
+				t.Fatalf("NodeCount = %d, want 1", diag.NodeCount)
+			}
+			if len(data) == 0 {
+				t.Fatalf("empty output for target %s", target)
+			}
+		})
+	}
+}

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -80,6 +80,10 @@ func New(opts Options) (*Client, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid proxy %q: %w", opts.Proxy, err)
 		}
+		// Go's http.Transport natively supports "socks5", map "socks5h" to it.
+		if strings.EqualFold(pu.Scheme, "socks5h") {
+			pu.Scheme = "socks5"
+		}
 		tr.Proxy = http.ProxyURL(pu)
 	} else {
 		// Otherwise honour the standard HTTP_PROXY / HTTPS_PROXY / NO_PROXY

--- a/internal/generator/features_test.go
+++ b/internal/generator/features_test.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"context"
+	"encoding/base64"
 	"strings"
 	"testing"
 
@@ -128,5 +129,59 @@ func TestApplyNodeOptions_AppendType(t *testing.T) {
 	}
 	if nodes[0].Clash["name"] != nodes[0].Name {
 		t.Error("append_type did not sync Clash[name]")
+	}
+}
+
+func TestGenerateSocks5AllTargets(t *testing.T) {
+	node := proxy.New("socks5", "Tailscale", "100.106.251.111", 1080)
+	node.Set("username", "myuser")
+	node.Set("password", "mypass")
+	node.SetRaw("udp", true)
+
+	cfg := &extconfig.Config{
+		EnableRuleGenerator: true,
+		ProxyGroups:         []extconfig.ProxyGroup{{Name: "Proxy", Type: "select", Selectors: []string{".*"}}},
+		Rulesets:            []extconfig.Ruleset{{Group: "Proxy", Inline: "FINAL"}},
+	}
+	f := fakeFetcher{}
+
+	// Clash
+	clash, err := GenerateClash(context.Background(), []*proxy.Proxy{node}, cfg, f, Options{})
+	if err != nil || !strings.Contains(string(clash.Output), "type: socks5") {
+		t.Fatalf("clash socks5 failed: %v\n%s", err, clash.Output)
+	}
+
+	// Singbox
+	singbox, err := GenerateSingbox(context.Background(), []*proxy.Proxy{node}, cfg, f, Options{})
+	if err != nil || !strings.Contains(string(singbox.Output), `"type": "socks"`) {
+		t.Fatalf("singbox socks5 failed: %v\n%s", err, singbox.Output)
+	}
+
+	// Surge
+	surge, err := GenerateSurge(context.Background(), []*proxy.Proxy{node}, cfg, f, Options{})
+	if err != nil || !strings.Contains(string(surge.Output), "socks5, 100.106.251.111, 1080") {
+		t.Fatalf("surge socks5 failed: %v\n%s", err, surge.Output)
+	}
+
+	// Loon
+	loon, err := GenerateLoon(context.Background(), []*proxy.Proxy{node}, cfg, f, Options{})
+	if err != nil || !strings.Contains(string(loon.Output), "SOCKS5,100.106.251.111,1080") {
+		t.Fatalf("loon socks5 failed: %v\n%s", err, loon.Output)
+	}
+
+	// QuanX
+	quanx, err := GenerateQuanX(context.Background(), []*proxy.Proxy{node}, cfg, f, Options{})
+	if err != nil || !strings.Contains(string(quanx.Output), "socks5=100.106.251.111:1080") {
+		t.Fatalf("quanx socks5 failed: %v\n%s", err, quanx.Output)
+	}
+
+	// V2Ray
+	v2ray, err := GenerateV2ray(context.Background(), []*proxy.Proxy{node}, cfg, f, Options{})
+	if err != nil {
+		t.Fatalf("v2ray socks5 failed: %v", err)
+	}
+	v2decoded, _ := base64.StdEncoding.DecodeString(string(v2ray.Output))
+	if !strings.Contains(string(v2decoded), "socks5://myuser:mypass@100.106.251.111:1080#Tailscale") {
+		t.Fatalf("v2ray socks5 share link mismatch: %s", v2decoded)
 	}
 }

--- a/internal/generator/quanx.go
+++ b/internal/generator/quanx.go
@@ -189,6 +189,20 @@ func quanxNodeLine(n *proxy.Proxy) (string, bool) {
 		}
 		parts = append(parts, tag)
 		return strings.Join(parts, ", "), true
+
+	case "socks5", "socks":
+		parts := []string{"socks5=" + addr}
+		if u := cs(c, "username"); u != "" {
+			parts = append(parts, "username="+u)
+		}
+		if pw := cs(c, "password"); pw != "" {
+			parts = append(parts, "password="+pw)
+		}
+		if cb(c, "udp") {
+			parts = append(parts, "udp-relay=true")
+		}
+		parts = append(parts, tag)
+		return strings.Join(parts, ", "), true
 	}
 	return "", false
 }

--- a/internal/generator/singbox.go
+++ b/internal/generator/singbox.go
@@ -251,6 +251,17 @@ func nodeSingboxOutbound(n *proxy.Proxy) (map[string]any, bool) {
 		}
 		base["tls"] = singboxTLS(c, cs(c, "sni"), true)
 		return base, true
+
+	case "socks5", "socks":
+		base["type"] = "socks"
+		base["version"] = "5"
+		if u := cs(c, "username"); u != "" {
+			base["username"] = u
+		}
+		if pw := cs(c, "password"); pw != "" {
+			base["password"] = pw
+		}
+		return base, true
 	}
 	return nil, false
 }

--- a/internal/generator/surge.go
+++ b/internal/generator/surge.go
@@ -230,6 +230,19 @@ func surgeNodeLine(flavor surgeFlavor, n *proxy.Proxy) (string, bool) {
 		}
 		parts = append(parts, surgeWSParts(c)...)
 		return head + strings.Join(parts, ", "), true
+
+	case "socks5", "socks":
+		parts := []string{"socks5", server, port}
+		if u := cs(c, "username"); u != "" {
+			parts = append(parts, "username="+u)
+		}
+		if pw := cs(c, "password"); pw != "" {
+			parts = append(parts, "password="+pw)
+		}
+		if cb(c, "udp") {
+			parts = append(parts, "udp-relay=true")
+		}
+		return head + strings.Join(parts, ", "), true
 	}
 	return "", false
 }
@@ -320,6 +333,18 @@ func loonNodeLine(n *proxy.Proxy) (string, bool) {
 		}
 		if cb(c, "skip-cert-verify") {
 			parts = append(parts, "skip-cert-verify=true")
+		}
+		return head + strings.Join(parts, ","), true
+
+	case "socks5", "socks":
+		parts := []string{"SOCKS5", server, port}
+		u := cs(c, "username")
+		pw := cs(c, "password")
+		if u != "" || pw != "" {
+			parts = append(parts, q(u), q(pw))
+		}
+		if cb(c, "udp") {
+			parts = append(parts, "udp=true")
 		}
 		return head + strings.Join(parts, ","), true
 	}

--- a/internal/generator/v2ray.go
+++ b/internal/generator/v2ray.go
@@ -155,6 +155,16 @@ func nodeShareLink(n *proxy.Proxy) (string, bool) {
 			q.Set("allow_insecure", "1")
 		}
 		return "tuic://" + cs(c, "uuid") + ":" + cs(c, "password") + "@" + hostport + "?" + q.Encode() + frag, true
+
+	case "socks5", "socks":
+		link := "socks5://"
+		u := cs(c, "username")
+		pw := cs(c, "password")
+		if u != "" || pw != "" {
+			link += url.UserPassword(u, pw).String() + "@"
+		}
+		link += hostport + frag
+		return link, true
 	}
 	return "", false
 }

--- a/internal/generator/v2ray_test.go
+++ b/internal/generator/v2ray_test.go
@@ -24,6 +24,7 @@ func TestGenerateV2ray_RoundTrip(t *testing.T) {
 		"trojan://pass@sg.example.com:443?sni=sg.example.com&type=ws&host=sg.example.com&path=/tj#SG",
 		"hysteria2://authpass@hk2.example.com:443?sni=hk2.example.com&insecure=1&obfs=salamander&obfs-password=xyz#HK2",
 		"tuic://uuid-3:tpass@tw.example.com:443?congestion_control=bbr&alpn=h3&sni=tw.example.com#TW",
+		"socks5://user:pass@s.example.com:1080#SK",
 	}
 	sub := []byte(base64.StdEncoding.EncodeToString([]byte(strings.Join(links, "\n"))))
 
@@ -31,8 +32,8 @@ func TestGenerateV2ray_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse input: %v", err)
 	}
-	if len(nodes) != 6 {
-		t.Fatalf("parsed %d input nodes, want 6", len(nodes))
+	if len(nodes) != 7 {
+		t.Fatalf("parsed %d input nodes, want 7", len(nodes))
 	}
 
 	res, err := GenerateV2ray(context.Background(), nodes, &extconfig.Config{}, fakeFetcher{}, Options{})
@@ -63,10 +64,10 @@ func TestGenerateV2ray_RoundTrip(t *testing.T) {
 }
 
 func TestGenerateV2ray_SkipsUnsupported(t *testing.T) {
-	// socks5 has no share-link form here -> reported, not emitted.
+	// anytls has no share-link form here -> reported, not emitted.
 	links := []string{
 		"ss://" + b64("aes-256-gcm:pass") + "@1.2.3.4:8388#OK",
-		"socks://" + b64("user:pass") + "@5.6.7.8:1080#SOCKS",
+		"anytls://mypassword@a.example.com:8443?sni=sni.example.com#AT",
 	}
 	sub := []byte(base64.StdEncoding.EncodeToString([]byte(strings.Join(links, "\n"))))
 	nodes, _, err := parser.Parse(sub)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -18,6 +18,29 @@ import (
 // lineParser parses a single share link of one protocol.
 type lineParser func(uri string) (*proxy.Proxy, error)
 
+// schemeOrder defines schemes checked in descending length order to avoid prefix ambiguities.
+var schemeOrder = []string{
+	"hysteria2://",
+	"hysteria://",
+	"wireguard://",
+	"socks5h://",
+	"socks4a://",
+	"socks5://",
+	"socks4://",
+	"socks://",
+	"trojan://",
+	"anytls://",
+	"vmess://",
+	"vless://",
+	"tuic://",
+	"ssr://",
+	"ss://",
+	"hy2://",
+	"hy://",
+	"wg://",
+	"tg://socks",
+}
+
 // registry maps a URI scheme prefix to its parser.
 var registry = map[string]lineParser{
 	"ss://":        parseSS,
@@ -32,17 +55,21 @@ var registry = map[string]lineParser{
 	"tuic://":      parseTUIC,
 	"socks://":     parseSOCKS,
 	"socks5://":    parseSOCKS,
+	"socks5h://":   parseSOCKS,
+	"socks4://":    parseSOCKS,
+	"socks4a://":   parseSOCKS,
+	"tg://socks":   parseSOCKS,
 	"anytls://":    parseAnyTLS,
 	"wireguard://": parseWireGuard,
 	"wg://":        parseWireGuard,
 }
 
-// matchScheme returns the registry scheme that prefixes s, or "" when s is
-// not a share link. No scheme in the registry is a prefix of another, so the
-// map iteration order never affects the result.
+// matchScheme returns the registry scheme that prefixes s (matched case-insensitively),
+// or "" when s is not a share link.
 func matchScheme(s string) string {
-	for scheme := range registry {
-		if strings.HasPrefix(s, scheme) {
+	lower := strings.ToLower(s)
+	for _, scheme := range schemeOrder {
+		if strings.HasPrefix(lower, scheme) {
 			return scheme
 		}
 	}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -234,9 +234,16 @@ func TestIsShareLink(t *testing.T) {
 		"tuic://uuid:pw@h:443#n",
 		"socks://user:pass@h:1080#n",
 		"socks5://h:1080#n",
+		"socks5://100.106.251.111:1080#Tailscale",
+		"SOCKS5://100.106.251.111:1080#Tailscale",
+		"socks5h://h:1080#n",
+		"socks4://h:1080#n",
+		"socks4a://h:1080#n",
+		"tg://socks?server=h&port=1080",
 		"anytls://pass@h:443#n",
 		"wireguard://key@h:51820#n",
 		"wg://key@h:51820#n",
+		"VLESS://uuid@h:443?type=tcp#n",
 	}
 	for _, l := range links {
 		if !IsShareLink(l) {

--- a/internal/parser/protocols_test.go
+++ b/internal/parser/protocols_test.go
@@ -88,6 +88,43 @@ func TestParseSOCKS_PlainAndBase64(t *testing.T) {
 	if p2.Clash["username"] != "alice" || p2.Clash["password"] != "s3cret" {
 		t.Errorf("decoded user/pass = %v/%v", p2.Clash["username"], p2.Clash["password"])
 	}
+
+	// No auth socks5 link (like Tailscale node).
+	p3, err := parseSOCKS("socks5://100.106.251.111:1080#Tailscale")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p3.Type != "socks5" || p3.Server != "100.106.251.111" || p3.Port != 1080 || p3.Name != "Tailscale" {
+		t.Errorf("bad socks5 no-auth fields: %+v", p3)
+	}
+	if _, ok := p3.Clash["username"]; ok {
+		t.Errorf("username should not be set when empty")
+	}
+
+	// Full base64 host part.
+	fullB64 := b64("myuser:mypass@100.106.251.111:1080")
+	p4, err := parseSOCKS("socks5://" + fullB64 + "#B64Tailscale")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p4.Server != "100.106.251.111" || p4.Port != 1080 || p4.Name != "B64Tailscale" {
+		t.Errorf("bad socks5 full-b64 fields: %+v", p4)
+	}
+	if p4.Clash["username"] != "myuser" || p4.Clash["password"] != "mypass" {
+		t.Errorf("bad socks5 full-b64 creds: %v/%v", p4.Clash["username"], p4.Clash["password"])
+	}
+
+	// tg://socks format.
+	p5, err := parseSOCKS("tg://socks?server=100.106.251.111&port=1080&user=tguser&pass=tgpass#TGSocks")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p5.Server != "100.106.251.111" || p5.Port != 1080 || p5.Name != "TGSocks" {
+		t.Errorf("bad tg://socks fields: %+v", p5)
+	}
+	if p5.Clash["username"] != "tguser" || p5.Clash["password"] != "tgpass" {
+		t.Errorf("bad tg://socks creds: %v/%v", p5.Clash["username"], p5.Clash["password"])
+	}
 }
 
 func TestParseAnyTLS(t *testing.T) {

--- a/internal/parser/socks.go
+++ b/internal/parser/socks.go
@@ -8,35 +8,59 @@ import (
 	"github.com/Jungley8/subconverter-ng/internal/proxy"
 )
 
-// parseSOCKS handles socks:// and socks5:// links.
+// parseSOCKS handles socks://, socks5://, socks5h://, socks4://, socks4a://, and tg://socks links.
 //
+//	socks5://[user:pass@]host:port#name
 //	socks5://[base64(user:pass)@]host:port#name
-//	socks5://user:pass@host:port#name
+//	socks5://base64([user:pass@]host:port)#name
+//	tg://socks?server=host&port=port&user=user&pass=pass#name
 func parseSOCKS(uri string) (*proxy.Proxy, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
 		return nil, fmt.Errorf("socks: %w", err)
 	}
-	host := u.Hostname()
-	port := atoiPort(u.Port())
+
+	var host, username, password string
+	var port int
+
+	if strings.HasPrefix(strings.ToLower(uri), "tg://") {
+		q := u.Query()
+		host = q.Get("server")
+		port = atoiPort(q.Get("port"))
+		username = q.Get("user")
+		password = q.Get("pass")
+	} else {
+		host = u.Hostname()
+		port = atoiPort(u.Port())
+
+		// If host/port could not be parsed directly, try base64 decoding the host part.
+		if (host == "" || port == 0) && u.Host != "" {
+			if dec, ok := b64decode(u.Host); ok && dec != u.Host {
+				if at := strings.LastIndex(dec, "@"); at != -1 {
+					username, password = splitCred(dec[:at])
+					host, port = splitHostPort(dec[at+1:])
+				} else {
+					host, port = splitHostPort(dec)
+				}
+			}
+		}
+
+		if u.User != nil {
+			username = u.User.Username()
+			password, _ = u.User.Password()
+			// Some producers base64 the whole "user:pass" in the userinfo.
+			if password == "" && username != "" {
+				if dec, ok := b64decode(username); ok && strings.Contains(dec, ":") {
+					username, password = splitCred(dec)
+				}
+			}
+		}
+	}
+
 	if host == "" || port == 0 {
 		return nil, fmt.Errorf("socks: missing host/port")
 	}
 	name := fragmentName(u, fmt.Sprintf("%s:%d", host, port))
-
-	var username, password string
-	if u.User != nil {
-		username = u.User.Username()
-		password, _ = u.User.Password()
-		// Some producers base64 the whole "user:pass" in the userinfo.
-		if password == "" && username != "" {
-			if dec, ok := b64decode(username); ok && strings.Contains(dec, ":") {
-				idx := strings.Index(dec, ":")
-				username = dec[:idx]
-				password = dec[idx+1:]
-			}
-		}
-	}
 
 	p := proxy.New("socks5", name, host, port)
 	p.Set("username", username)


### PR DESCRIPTION
### Summary

- **Scheme Matching**: Added `socks5://`, `socks://`, `socks5h://`, `socks4://`, `socks4a://`, and `tg://socks` to scheme matching (with case-insensitive matching).
- **Parser**: Enhanced `parseSOCKS` to handle no-auth links (`socks5://host:port#name`), base64 credentials, full-link base64, and `tg://socks`.
- **Generators**: Added SOCKS5 node generation across all target formats (Clash, sing-box, Surge, Shadowrocket, Loon, Quantumult X, V2Ray mixed).
- **Upstream Proxy**: Normalized `socks5h://` to `socks5://` for Go's `http.ProxyURL` in `fetch`.
- **Tests**: Added comprehensive test cases across parser, generator, and convert modules.