### PR TITLE
feat: add tailscale option to prepend Tailscale direct rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ dist/
 
 # agent worktrees
 .claude/
+.omo/
 /site/

--- a/README.en.md
+++ b/README.en.md
@@ -19,7 +19,7 @@ targeting **Clash.Meta / mihomo** so new protocols work right away.
 
 - ✅ **Compatible API**: `/sub?target=clash&url=...&config=...` — existing clients keep working unchanged
 - ✅ **Protocols**: Shadowsocks, ShadowsocksR, VMess, VLESS (Reality / XTLS-Vision), Trojan, Hysteria (v1/v2), TUIC v5, AnyTLS, SOCKS5, **WireGuard**
-- ✅ **Node processing**: dedup (`dedup`), filter unsupported nodes (`fdn`), append protocol type (`append_type`), regex `rename`, emoji add/remove (subconverter-compatible)
+- ✅ **Node processing**: dedup (`dedup`), filter unsupported nodes (`fdn`), append protocol type (`append_type`), Tailscale DIRECT rules (`tailscale`), regex `rename`, emoji add/remove (subconverter-compatible)
 - ✅ **Cache / rate-limit**: TTL cache for rulesets & subscriptions (on by default, flushable), per-IP rate limiting
 - ✅ **Subscription-Userinfo passthrough**: clients show airport traffic / expiry directly
 - ✅ **rule-providers output** (`expand=false`), proxies-only output (`list`)
@@ -82,6 +82,7 @@ Full list in [docs/url-params.md](docs/url-params.md). Common ones:
 | `fdn` | drop nodes Clash.Meta can't use (e.g. SS with a retired cipher) |
 | `list` | output only the node list (no groups / rules, **clash only**) |
 | `append_type` | prepend `[TYPE]` to node names |
+| `tailscale` | prepend Tailscale DIRECT rules (`100.64.0.0/10`, `fd7a:115c:a1e0::/48`) to rules |
 | `expand` | `false` emits rule-providers referencing remote rules (**clash only**) |
 | `emoji` `add_emoji` `remove_emoji` | emoji add/remove (subconverter-compatible) |
 | `udp` `tfo` `scv` | per-node toggles (target-dependent) |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 - ✅ **接口兼容**：`/sub?target=clash&url=...&config=...`，老客户端无需改动
 - ✅ **协议**：Shadowsocks、ShadowsocksR、VMess、VLESS（含 Reality / XTLS-Vision）、Trojan、Hysteria（v1/v2）、TUIC v5、AnyTLS、SOCKS5、**WireGuard**
-- ✅ **节点处理**：去重（`dedup`）、过滤不支持的节点（`fdn`）、追加协议类型（`append_type`）、`rename` 正则重命名、emoji 增删（对齐 subconverter）
+- ✅ **节点处理**：去重（`dedup`）、过滤不支持的节点（`fdn`）、追加协议类型（`append_type`）、Tailscale 直连规则（`tailscale`）、`rename` 正则重命名、emoji 增删（对齐 subconverter）
 - ✅ **缓存 / 限流**：规则与订阅 TTL 缓存（默认开，可清除）、按 IP 限流防滥用
 - ✅ **Subscription-Userinfo 透传**：客户端直接显示机场流量 / 到期
 - ✅ **rule-providers 输出**（`expand=false`）、仅节点列表输出（`list`）
@@ -79,6 +79,7 @@ docker compose up -d
 | `fdn` | 过滤 Clash.Meta 不支持的节点（如废弃加密的 SS） |
 | `list` | 仅输出节点列表（无分组 / 规则，**仅 clash**） |
 | `append_type` | 节点名前加 `[类型]` |
+| `tailscale` | 在规则最前面添加 Tailscale 直连规则（`100.64.0.0/10`, `fd7a:115c:a1e0::/48`） |
 | `expand` | `false` 时输出 rule-providers 引用远程规则（**仅 clash**） |
 | `emoji` `add_emoji` `remove_emoji` | emoji 增删（对齐 subconverter） |
 | `udp` `tfo` `scv` | 节点开关（部分 target 有效） |

--- a/cmd/subconverter-ng/main.go
+++ b/cmd/subconverter-ng/main.go
@@ -113,6 +113,7 @@ func cmdConvert(args []string) {
 	fdn := fs.Bool("fdn", false, "filter nodes Clash.Meta cannot use")
 	list := fs.Bool("list", false, "output only the node list (no groups/rules)")
 	appendType := fs.Bool("append-type", false, "prepend [TYPE] to node names")
+	tailscale := fs.Bool("tailscale", false, "prepend Tailscale DIRECT rules (100.64.0.0/10, fd7a:115c:a1e0::/48)")
 	insert := fs.String("insert", "", "insert_url: extra node source URL(s), '|'-separated, merged into the output")
 	insertPrepend := fs.Bool("insert-prepend", true, "place inserted nodes before subscription nodes")
 	timeout := fs.Duration("timeout", 30*time.Second, "per-fetch timeout")
@@ -147,6 +148,7 @@ func cmdConvert(args []string) {
 			FilterDeprecated: *fdn,
 			AppendType:       *appendType,
 			ListOnly:         *list,
+			Tailscale:        *tailscale,
 		},
 		Emoji:       triFromString(*emoji),
 		AddEmoji:    triFromString(*addEmoji),

--- a/docs/url-params.en.md
+++ b/docs/url-params.en.md
@@ -32,6 +32,7 @@ Query parameters for `GET /sub`, kept as compatible as possible with [tindy2013/
 | `sort` | Sort by node name | :material-check: |
 | `dedup` | Remove duplicate nodes: nodes with identical connection fields (type/address/port/credentials/transport) keep only the first | :material-check: |
 | `append_type` | Prefix node names with `[type]` (e.g. `[SS] HK 01`) | :material-check: |
+| `tailscale` | Prepend Tailscale DIRECT rules (`100.64.0.0/10` and `fd7a:115c:a1e0::/48` with `no-resolve`) to the very beginning of the rules list | :material-check: |
 | `emoji` | Shortcut: `true` = strip old emoji then add flags by rule; `false` = strip emoji and add none. Equivalent to `add_emoji=<value>` plus `remove_emoji=true` | :material-check: |
 | `add_emoji` | Whether to prepend flag emoji to node names by rule (default `true`) | :material-check: |
 | `remove_emoji` | Whether to first remove existing emoji in node names (default `true`) | :material-check: |

--- a/docs/url-params.md
+++ b/docs/url-params.md
@@ -31,6 +31,7 @@
 | `sort` | 按节点名排序 | :material-check: |
 | `dedup` | 去除重复节点：连接字段（类型/地址/端口/凭据/传输）完全相同的节点只保留第一个 | :material-check: |
 | `append_type` | 节点名前加 `[类型]`（如 `[SS] 香港 01`） | :material-check: |
+| `tailscale` | 在规则最前置入 Tailscale 直连规则（`100.64.0.0/10` 与 `fd7a:115c:a1e0::/48` 直连且 `no-resolve`） | :material-check: |
 | `emoji` | 快捷开关：`true`=去旧 emoji 后按规则统一加旗；`false`=去除 emoji 不再加。等价于 `add_emoji=<值>` 且 `remove_emoji=true` | :material-check: |
 | `add_emoji` | 是否按规则给节点名前加国旗 emoji（默认 `true`） | :material-check: |
 | `remove_emoji` | 是否先移除节点名中已有的 emoji（默认 `true`） | :material-check: |

--- a/docs/web.en.md
+++ b/docs/web.en.md
@@ -17,7 +17,7 @@ http://127.0.0.1:25500/
 1. **Subscription link**: paste your provider's subscription URL into the text box, one per line; multiple lines are automatically joined with `|`.
 2. **External config (optional)**: enter the URL of an INI rules config (subconverter / ACL4SSR compatible).
 3. **target**: choose the output format from the dropdown — `clash` (Clash.Meta / mihomo), `singbox`, `surge`, `shadowrocket`, `quanx`, `loon`, `v2ray`/`mixed`.
-4. **Options**: tick `sort nodes`, `dedup nodes`, `force UDP`, `TCP Fast Open`, `skip cert verify`, `filter incompatible nodes`, `append type to name`, `allow emoji` as needed. These map to the [URL parameters](url-params.md) `sort` / `dedup` / `udp` / `tfo` / `scv` / `fdn` / `append_type` / `emoji`.
+4. **Options**: tick `sort nodes`, `dedup nodes`, `force UDP`, `TCP Fast Open`, `skip cert verify`, `filter incompatible nodes`, `append type to name`, `Tailscale DIRECT`, `allow emoji` as needed. These map to the [URL parameters](url-params.md) `sort` / `dedup` / `udp` / `tfo` / `scv` / `fdn` / `append_type` / `tailscale` / `emoji`.
 5. **Upstream proxy (optional)**: e.g. `socks5://127.0.0.1:1080`, applied to this request only, overriding the global config.
 6. Click **Generate subscription link** and the full `/sub?...` link appears below.
 7. Click **Copy** and paste the link into your Clash / mihomo client's "Config URL"; or click **Open / Preview** to view the converted result directly in a new tab.

--- a/docs/web.md
+++ b/docs/web.md
@@ -17,7 +17,7 @@ http://127.0.0.1:25500/
 1. **订阅链接**：在文本框里粘贴机场订阅地址，一行一个，多个会自动用 `|` 合并。
 2. **外部配置 config**（可选）：填入 INI 规则配置的 URL（兼容 subconverter / ACL4SSR）。
 3. **目标 target**：下拉选择输出格式 —— `clash`（Clash.Meta / mihomo）、`singbox`、`surge`、`shadowrocket`、`quanx`、`loon`、`v2ray`/`mixed`。
-4. **选项**：按需勾选 `节点排序`、`节点去重`、`强制 UDP`、`TCP Fast Open`、`跳过证书校验`、`过滤不兼容节点`、`节点名加类型`、`允许 emoji`。对应 [URL 参数](url-params.md) 里的 `sort` / `dedup` / `udp` / `tfo` / `scv` / `fdn` / `append_type` / `emoji`。
+4. **选项**：按需勾选 `节点排序`、`节点去重`、`强制 UDP`、`TCP Fast Open`、`跳过证书校验`、`过滤不兼容节点`、`节点名加类型`、`Tailscale 直连`、`允许 emoji`。对应 [URL 参数](url-params.md) 里的 `sort` / `dedup` / `udp` / `tfo` / `scv` / `fdn` / `append_type` / `tailscale` / `emoji`。
 5. **上游代理 proxy**（可选）：例如 `socks5://127.0.0.1:1080`，仅对本次请求生效，覆盖全局配置。
 6. 点击 **生成订阅链接**，下方会显示完整的 `/sub?...` 链接。
 7. 点击 **复制**，把链接粘贴到 Clash / mihomo 客户端的「配置 URL」即可；也可以点 **打开 / 预览** 在新标签页直接查看转换结果。

--- a/internal/convert/convert_test.go
+++ b/internal/convert/convert_test.go
@@ -455,3 +455,33 @@ func TestRawSocks5ShareLinkDirect(t *testing.T) {
 		})
 	}
 }
+
+func TestRun_TailscaleOption(t *testing.T) {
+	f := fakeFetcher{
+		"client/subscribe": sampleSubscription(),
+		"config.init":      []byte(sampleINI),
+		"PROXY.list":       []byte(samplePROXYList),
+	}
+	req := Request{
+		Target:    "clash",
+		SubURLs:   []string{"https://airport.example.com/api/v1/client/subscribe?token=x"},
+		ConfigURL: "https://github.com/x/config.init",
+	}
+	req.Gen.Tailscale = true
+	data, _, err := Run(context.Background(), f, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Rules []string `yaml:"rules"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatal(err)
+	}
+	if len(doc.Rules) < 2 {
+		t.Fatalf("rules len=%d, want >=2", len(doc.Rules))
+	}
+	if doc.Rules[0] != "IP-CIDR,100.64.0.0/10,DIRECT,no-resolve" || doc.Rules[1] != "IP-CIDR,fd7a:115c:a1e0::/48,DIRECT,no-resolve" {
+		t.Errorf("rules[0..1] mismatch with tailscale option: %v", doc.Rules[:2])
+	}
+}

--- a/internal/generator/clash.go
+++ b/internal/generator/clash.go
@@ -59,6 +59,11 @@ type Options struct {
 	// ListOnly emits only the proxies list (the `proxies:` document) with no
 	// groups or rules. Maps to &list=true.
 	ListOnly bool
+
+	// Tailscale, when true, prepends Tailscale DIRECT rules
+	// (100.64.0.0/10 and fd7a:115c:a1e0::/48) to the top of the rule list.
+	// Maps to &tailscale=true.
+	Tailscale bool
 }
 
 // RenameRule is a compiled rename= entry: a regex pattern and its replacement.
@@ -171,10 +176,10 @@ func GenerateClash(ctx context.Context, nodes []*proxy.Proxy, cfg *extconfig.Con
 	var rules []string
 	var providers map[string]any
 	if opts.UseRuleProviders {
-		rules, providers, res.SkippedRules = buildRuleProviders(cfg)
+		rules, providers, res.SkippedRules = buildRuleProviders(cfg, opts)
 	} else {
 		var skippedRules []string
-		rules, skippedRules = buildRules(ctx, cfg, f)
+		rules, skippedRules = buildRules(ctx, cfg, f, opts)
 		res.SkippedRules = skippedRules
 	}
 
@@ -197,6 +202,16 @@ func GenerateClash(ctx context.Context, nodes []*proxy.Proxy, cfg *extconfig.Con
 				}
 				if cfg.OverwriteRules || base["rules"] == nil {
 					base["rules"] = rules
+				} else if opts.Tailscale {
+					ts := []any{
+						"IP-CIDR,100.64.0.0/10,DIRECT,no-resolve",
+						"IP-CIDR,fd7a:115c:a1e0::/48,DIRECT,no-resolve",
+					}
+					if existing, ok := base["rules"].([]any); ok {
+						base["rules"] = append(ts, existing...)
+					} else {
+						base["rules"] = ts
+					}
 				}
 				y, err := yaml.Marshal(base)
 				if err != nil {
@@ -443,8 +458,8 @@ func resolveSelectors(selectors []string, nodes []*proxy.Proxy, allNames []strin
 // buildRules expands all rulesets in declared order into Clash rule lines. The
 // concurrent fetch + neutral parsing lives in collectRules (common.go); this
 // just formats each neutral Rule as a Clash rule string.
-func buildRules(ctx context.Context, cfg *extconfig.Config, f Fetcher) (rules, skipped []string) {
-	neutral, skipped := collectRules(ctx, cfg, f)
+func buildRules(ctx context.Context, cfg *extconfig.Config, f Fetcher, opts Options) (rules, skipped []string) {
+	neutral, skipped := collectRules(ctx, cfg, f, opts)
 	for _, r := range neutral {
 		if line, ok := formatClashRule(r); ok {
 			rules = append(rules, line)
@@ -461,9 +476,15 @@ func buildRules(ctx context.Context, cfg *extconfig.Config, f Fetcher) (rules, s
 // its group. Inline rulesets ([]GEOIP,CN, []FINAL) stay direct rules so MATCH
 // and inline matchers still work. Providers are deduped by URL: a URL reused
 // across groups yields one provider but a RULE-SET line per (provider,group).
-func buildRuleProviders(cfg *extconfig.Config) (rules []string, providers map[string]any, skipped []string) {
+func buildRuleProviders(cfg *extconfig.Config, opts Options) (rules []string, providers map[string]any, skipped []string) {
+	if opts.Tailscale {
+		rules = append(rules,
+			"IP-CIDR,100.64.0.0/10,DIRECT,no-resolve",
+			"IP-CIDR,fd7a:115c:a1e0::/48,DIRECT,no-resolve",
+		)
+	}
 	if !cfg.EnableRuleGenerator {
-		return nil, nil, nil
+		return rules, providers, nil
 	}
 	providerByURL := map[string]string{} // url -> provider key
 	seenRuleSet := map[string]bool{}     // "provider\x00group" -> emitted

--- a/internal/generator/common.go
+++ b/internal/generator/common.go
@@ -109,13 +109,24 @@ func formatClashRule(r Rule) (string, bool) {
 	return s, true
 }
 
+// tailscaleRules are prepended to the rule list when Options.Tailscale is true.
+var tailscaleRules = []Rule{
+	{Type: "IP-CIDR", Value: "100.64.0.0/10", Group: "DIRECT", Flag: "no-resolve"},
+	{Type: "IP-CIDR", Value: "fd7a:115c:a1e0::/48", Group: "DIRECT", Flag: "no-resolve"},
+}
+
 // collectRules expands every ruleset in declared order into neutral Rule values.
 // Remote rulesets are fetched concurrently but assembled in declared order;
 // inline rulesets ([]GEOIP,CN, []FINAL) are expanded directly. Entries with an
 // unsupported rule type are returned in skipped instead of rules.
-func collectRules(ctx context.Context, cfg *extconfig.Config, f Fetcher) (rules []Rule, skipped []string) {
+// When opts.Tailscale is true, Tailscale direct rules are prepended.
+func collectRules(ctx context.Context, cfg *extconfig.Config, f Fetcher, opts Options) (rules []Rule, skipped []string) {
+	var tsRules []Rule
+	if opts.Tailscale {
+		tsRules = append(tsRules, tailscaleRules...)
+	}
 	if !cfg.EnableRuleGenerator {
-		return nil, nil
+		return tsRules, nil
 	}
 	type fetched struct {
 		rules   []Rule
@@ -151,7 +162,7 @@ func collectRules(ctx context.Context, cfg *extconfig.Config, f Fetcher) (rules 
 		rules = append(rules, results[i].rules...)
 		skipped = append(skipped, results[i].skipped...)
 	}
-	return rules, skipped
+	return append(tsRules, rules...), skipped
 }
 
 // parseInlineRule turns a []inline body into a neutral Rule. Types are kept

--- a/internal/generator/features_test.go
+++ b/internal/generator/features_test.go
@@ -185,3 +185,79 @@ func TestGenerateSocks5AllTargets(t *testing.T) {
 		t.Fatalf("v2ray socks5 share link mismatch: %s", v2decoded)
 	}
 }
+
+func TestGenerateTailscaleRules(t *testing.T) {
+	nodes := mkNodes()
+	cfg := &extconfig.Config{
+		EnableRuleGenerator: true,
+		ProxyGroups:         []extconfig.ProxyGroup{{Name: "Proxy", Type: "select", Selectors: []string{".*"}}},
+		Rulesets:            []extconfig.Ruleset{{Group: "Proxy", Inline: "FINAL"}},
+	}
+	f := fakeFetcher{}
+
+	// Clash (Inline)
+	clash, err := GenerateClash(context.Background(), nodes, cfg, f, Options{Tailscale: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Rules []string `yaml:"rules"`
+	}
+	if err := yaml.Unmarshal(clash.Output, &doc); err != nil {
+		t.Fatal(err)
+	}
+	if len(doc.Rules) < 3 {
+		t.Fatalf("clash rules len=%d, want >=3", len(doc.Rules))
+	}
+	if doc.Rules[0] != "IP-CIDR,100.64.0.0/10,DIRECT,no-resolve" || doc.Rules[1] != "IP-CIDR,fd7a:115c:a1e0::/48,DIRECT,no-resolve" {
+		t.Errorf("clash rules[0..1] mismatch: %v", doc.Rules[:2])
+	}
+
+	// Clash (RuleProviders)
+	clashRP, err := GenerateClash(context.Background(), nodes, cfg, f, Options{Tailscale: true, UseRuleProviders: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var docRP struct {
+		Rules []string `yaml:"rules"`
+	}
+	if err := yaml.Unmarshal(clashRP.Output, &docRP); err != nil {
+		t.Fatal(err)
+	}
+	if len(docRP.Rules) < 2 {
+		t.Fatalf("clashRP rules len=%d, want >=2", len(docRP.Rules))
+	}
+	if docRP.Rules[0] != "IP-CIDR,100.64.0.0/10,DIRECT,no-resolve" || docRP.Rules[1] != "IP-CIDR,fd7a:115c:a1e0::/48,DIRECT,no-resolve" {
+		t.Errorf("clashRP rules[0..1] mismatch: %v", docRP.Rules[:2])
+	}
+
+	// Surge
+	surge, err := GenerateSurge(context.Background(), nodes, cfg, f, Options{Tailscale: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(surge.Output)
+	ruleIdx := strings.Index(s, "[Rule]\n")
+	if ruleIdx == -1 {
+		t.Fatal("surge missing [Rule]")
+	}
+	ruleSection := s[ruleIdx+len("[Rule]\n"):]
+	if !strings.HasPrefix(ruleSection, "IP-CIDR,100.64.0.0/10,DIRECT,no-resolve\nIP-CIDR,fd7a:115c:a1e0::/48,DIRECT,no-resolve\n") {
+		t.Errorf("surge rule section does not start with tailscale rules:\n%s", ruleSection)
+	}
+
+	// QuanX
+	quanx, err := GenerateQuanX(context.Background(), nodes, cfg, f, Options{Tailscale: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	qs := string(quanx.Output)
+	filterIdx := strings.Index(qs, "[filter_local]\n")
+	if filterIdx == -1 {
+		t.Fatal("quanx missing [filter_local]")
+	}
+	filterSection := qs[filterIdx+len("[filter_local]\n"):]
+	if !strings.HasPrefix(filterSection, "ip-cidr, 100.64.0.0/10, DIRECT, no-resolve\nip-cidr, fd7a:115c:a1e0::/48, DIRECT, no-resolve\n") {
+		t.Errorf("quanx filter section does not start with tailscale rules:\n%s", filterSection)
+	}
+}

--- a/internal/generator/quanx.go
+++ b/internal/generator/quanx.go
@@ -43,7 +43,7 @@ func GenerateQuanX(ctx context.Context, nodes []*proxy.Proxy, cfg *extconfig.Con
 		b.WriteByte('\n')
 	}
 
-	neutral, skippedRules := collectRules(ctx, cfg, f)
+	neutral, skippedRules := collectRules(ctx, cfg, f, opts)
 	b.WriteString("\n[filter_local]\n")
 	for _, r := range neutral {
 		if line, ok := formatQuanXRule(r); ok {

--- a/internal/generator/singbox.go
+++ b/internal/generator/singbox.go
@@ -52,7 +52,7 @@ func GenerateSingbox(ctx context.Context, nodes []*proxy.Proxy, cfg *extconfig.C
 	)
 
 	// Route rules from neutral rules.
-	neutral, skippedRules := collectRules(ctx, cfg, f)
+	neutral, skippedRules := collectRules(ctx, cfg, f, opts)
 	routeRules := []map[string]any{{"protocol": "dns", "outbound": "dns-out"}}
 	final := "direct"
 	for _, r := range neutral {

--- a/internal/generator/surge.go
+++ b/internal/generator/surge.go
@@ -74,7 +74,7 @@ func generateSurgeFamily(ctx context.Context, flavor surgeFlavor, nodes []*proxy
 
 	// Rules: expand to neutral rules then format in Surge syntax, dropping types
 	// the family does not support.
-	neutral, skippedRules := collectRules(ctx, cfg, f)
+	neutral, skippedRules := collectRules(ctx, cfg, f, opts)
 	b.WriteString("\n[Rule]\n")
 	for _, r := range neutral {
 		if line, ok := formatSurgeRule(r); ok {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -189,6 +189,7 @@ func (s *Server) handleSub(w http.ResponseWriter, r *http.Request) {
 			FilterDeprecated: boolParam(q.Get("fdn"), false),
 			AppendType:       boolParam(q.Get("append_type"), false),
 			ListOnly:         boolParam(q.Get("list"), false),
+			Tailscale:        boolParam(q.Get("tailscale"), false),
 		},
 		// Emoji tribools (nil when the param is absent) resolved in convert.
 		Emoji:       boolTri(q.Get("emoji")),

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -299,3 +299,31 @@ func TestClientIP(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleSub_Tailscale(t *testing.T) {
+	air := fakeAirport()
+	defer air.Close()
+
+	h := New(config.Default()).Handler()
+	target := "/sub?target=clash&url=" + url.QueryEscape(air.URL+"/sub.txt") +
+		"&config=" + url.QueryEscape(air.URL+"/config.init") + "&tailscale=true"
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, target, nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var doc struct {
+		Rules []string `yaml:"rules"`
+	}
+	if err := yaml.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("invalid yaml: %v", err)
+	}
+	if len(doc.Rules) < 3 {
+		t.Fatalf("rules len=%d, want >=3", len(doc.Rules))
+	}
+	if doc.Rules[0] != "IP-CIDR,100.64.0.0/10,DIRECT,no-resolve" || doc.Rules[1] != "IP-CIDR,fd7a:115c:a1e0::/48,DIRECT,no-resolve" {
+		t.Errorf("rules[0..1] mismatch: %v", doc.Rules[:2])
+	}
+}

--- a/internal/web/assets/index.html
+++ b/internal/web/assets/index.html
@@ -189,6 +189,7 @@
           <label class="toggle"><input type="checkbox" id="scv"><span>跳过证书校验</span></label>
           <label class="toggle"><input type="checkbox" id="fdn"><span>过滤不兼容节点</span></label>
           <label class="toggle"><input type="checkbox" id="append_type"><span>节点名加类型</span></label>
+          <label class="toggle"><input type="checkbox" id="tailscale"><span>Tailscale 直连</span></label>
           <label class="toggle"><input type="checkbox" id="emoji" checked><span>允许 emoji</span></label>
         </div>
       </div>
@@ -231,7 +232,7 @@
   // keeps the user's subscription URLs, target and options. ---
   var STORE_KEY = 'subng.form.v1';
   var TEXT_FIELDS = ['urls', 'config', 'target', 'proxy']; // value-bearing inputs/selects
-  var FLAG_FIELDS = ['sort', 'dedup', 'udp', 'tfo', 'scv', 'fdn', 'append_type', 'emoji']; // checkboxes
+  var FLAG_FIELDS = ['sort', 'dedup', 'udp', 'tfo', 'scv', 'fdn', 'append_type', 'tailscale', 'emoji']; // checkboxes
 
   function saveState() {
     try {
@@ -271,7 +272,7 @@
     var config = $('config').value.trim();
     if (config) { params.push('config=' + encodeURIComponent(config)); }
 
-    ['sort', 'dedup', 'udp', 'tfo', 'scv', 'fdn', 'append_type'].forEach(function (k) {
+    ['sort', 'dedup', 'udp', 'tfo', 'scv', 'fdn', 'append_type', 'tailscale'].forEach(function (k) {
       if ($(k).checked) { params.push(k + '=true'); }
     });
     // Emoji are allowed by default; only signal removal when unchecked.


### PR DESCRIPTION
### Summary

- **Tailscale Rules**: When `tailscale` option is enabled (`&tailscale=true` / `--tailscale`), prepends Tailscale DIRECT rules to the top of the rules list:
  ```yaml
  - "IP-CIDR,100.64.0.0/10,DIRECT,no-resolve"
  - "IP-CIDR,fd7a:115c:a1e0::/48,DIRECT,no-resolve"
  ```
- **Targets**: Supported across all rule-bearing targets (Clash inline/rule-providers/rule-base, sing-box, Surge, Shadowrocket, Loon, Quantumult X).
- **Web UI & CLI**: Added toggle in Web UI and `--tailscale` flag in CLI `convert`.
- **Docs**: Updated parameter tables and guides.